### PR TITLE
Fixes Default Travis Build Errors and Timeout Problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
+sudo: required
 before_install:
-- "sudo apt-get update && sudo apt-get install -y --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended"
+- sudo apt-get -qq update && sudo apt-get install -y --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended
 script:
 - mkdir _build
 - pdflatex -output-directory _build tex/your_file_1.tex

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ before_install:
 - sudo apt-get -qq update && sudo apt-get install -y --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended
 script:
 - mkdir _build
-- pdflatex -output-directory _build tex/your_file_1.tex
-- pdflatex -output-directory _build tex/your_file_2.tex
+- pdflatex -interaction=nonstopmode -halt-on-error -output-directory _build tex/your_file_1.tex
+- pdflatex -interaction=nonstopmode -halt-on-error -output-directory _build tex/your_file_2.tex
 deploy:
   provider: releases
   api_key:


### PR DESCRIPTION
This fixes build errors by explicitly using Travis's old VM-based infrastructure, which still supports sudo.

It also makes the build fail faster by runnig pdflatex in non-interactive mode.
